### PR TITLE
some spelling problems

### DIFF
--- a/packages/billund-supportor/built/billund-supportor.js
+++ b/packages/billund-supportor/built/billund-supportor.js
@@ -1270,7 +1270,7 @@ var BaseFESupportor = function () {
     }, {
         key: SupportorEnums.BROWSER_SUPPORTOR_REGIST_STORE_CONFIG,
         value: function value() {
-            throw new Error('you should impletement ' + SupportorEnums.BROWSER_SUPPORTOR_REGIST_STORE_CONFIG + ' function.');
+            throw new Error('you should implement ' + SupportorEnums.BROWSER_SUPPORTOR_REGIST_STORE_CONFIG + ' function.');
         }
 
         /**
@@ -1632,7 +1632,7 @@ var BaseFESupportor = function () {
     }, {
         key: 'dispatch',
         value: function dispatch() {
-            throw new Error('you should impletement dispatch function.');
+            throw new Error('you should implement dispatch function.');
         }
 
         /**
@@ -1642,7 +1642,7 @@ var BaseFESupportor = function () {
     }, {
         key: 'getState',
         value: function getState() {
-            throw new Error('you should impletement getState function.');
+            throw new Error('you should implement getState function.');
         }
 
         /**
@@ -1652,7 +1652,7 @@ var BaseFESupportor = function () {
     }, {
         key: 'registStoreOnChangeListener',
         value: function registStoreOnChangeListener() {
-            throw new Error('you should impletement registStoreOnChangeListener function.');
+            throw new Error('you should implement registStoreOnChangeListener function.');
         }
 
         /**

--- a/packages/billund-supportor/lib/index.js
+++ b/packages/billund-supportor/lib/index.js
@@ -21,10 +21,10 @@ function addupRenderType() {
 
     configs.forEach((config) => {
         const renderType = config.renderType;
-        if (renderType == RenderTypeEnums.RENDER_TYPE_REACT) {
-            react++;
+        if (renderType === RenderTypeEnums.RENDER_TYPE_REACT) {
+            return react++;
         }
-        if (renderType == RenderTypeEnums.RENDER_TYPE_VUE) {
+        if (renderType === RenderTypeEnums.RENDER_TYPE_VUE) {
             vue++;
         }
     });
@@ -41,7 +41,7 @@ function addupRenderType() {
  */
 function init() {
     if (window[SupportorEnums.BROWSER_SUPPORTOR]) {
-        console.warn(`there are several different lego-supportor versions,please check.`);
+        console.warn(`there are several different billund-supportor versions, please check.`);
         return window[SupportorEnums.BROWSER_SUPPORTOR];
     }
     const renderTypeCounts = addupRenderType();

--- a/packages/billund-supportor/lib/supportor/basesupportor.js
+++ b/packages/billund-supportor/lib/supportor/basesupportor.js
@@ -219,7 +219,7 @@ class BaseFESupportor {
      * 注册store配置
      */
     [SupportorEnums.BROWSER_SUPPORTOR_REGIST_STORE_CONFIG]() {
-        throw new Error(`you should impletement ${SupportorEnums.BROWSER_SUPPORTOR_REGIST_STORE_CONFIG} function.`);
+        throw new Error(`you should implement ${SupportorEnums.BROWSER_SUPPORTOR_REGIST_STORE_CONFIG} function.`);
     }
 
     /**
@@ -517,21 +517,21 @@ class BaseFESupportor {
      * 分发action的操作
      */
     dispatch() {
-        throw new Error(`you should impletement dispatch function.`);
+        throw new Error(`you should implement dispatch function.`);
     }
 
     /**
      * 获取当前的state
      */
     getState() {
-        throw new Error(`you should impletement getState function.`);
+        throw new Error(`you should implement getState function.`);
     }
 
     /**
      * 注册store变更数据监听
      */
     registStoreOnChangeListener() {
-        throw new Error(`you should impletement registStoreOnChangeListener function.`);
+        throw new Error(`you should implement registStoreOnChangeListener function.`);
     }
 
     /**


### PR DESCRIPTION
ignore the changes in a built files...

in case `configs.forEach` , if a `renderType` should be `RenderTypeEnums.RENDER_TYPE_REACT`, it couldn't be other type anymore. I guess it's the time to return;

then I figure out some spelling problems. um...
