### PR TITLE
fix crash due to null watched

### DIFF
--- a/packages/billund-framework-core/lib/server/modules/actionbinder.js
+++ b/packages/billund-framework-core/lib/server/modules/actionbinder.js
@@ -144,6 +144,7 @@ function watchFilesChange() {
  * @param  {String} pathname - 当前文件
  */
 function collectFileAndChildren(pathname) {
+    if (!pathname) return;
     // 如果已经监听过，不做收集
     if (watched) return;
     // 因为超过调用上限的问题，不监听node_modules下的变化


### PR DESCRIPTION
`actionConfig.routerConfig` is optional, so `staticRc` is usually null. 

https://github.com/robinleej/billund/blob/master/packages/billund-framework-core/lib/server/modules/actionbinder.js#L54
```
let staticRc = null;
...
if (actionConfig.routerConfig) {
    staticRc = path.resolve(actionPathDir, actionConfig.routerConfig);
}
...
if (isDev) {
    collectFileAndChildren(actionPath);
    collectFileAndChildren(staticRc);
}
```